### PR TITLE
Fix the call to `deleteShader` so it references the correct program id

### DIFF
--- a/shader.go
+++ b/shader.go
@@ -113,14 +113,14 @@ func createProgram(v, f, g []byte) (uint32, error) {
 		return 0, err
 	} else {
 		vertex = val
-		defer deleteShader(p, vertex)
+		defer func(s uint32) { deleteShader(p, s) }(vertex)
 	}
 
 	if val, err := compileShader(string(f)+"\x00", gl.FRAGMENT_SHADER); err != nil {
 		return 0, err
 	} else {
 		frag = val
-		defer deleteShader(p, frag)
+		defer func(s uint32) { deleteShader(p, s) }(frag)
 	}
 
 	if len(g) > 0 {
@@ -128,7 +128,7 @@ func createProgram(v, f, g []byte) (uint32, error) {
 			return 0, err
 		} else {
 			geom = val
-			defer deleteShader(p, geom)
+			defer func(s uint32) { deleteShader(p, s) }(geom)
 		}
 	}
 


### PR DESCRIPTION
I noticed that the call to deleteShader was using the wrong program id when looking through the example code here. I thought it would be helpful to fix it for anyone like myself who is trying to learn OpenGL with Go.

The reason this happens is because a Go defer call will capture all of the arguments at the time it is called rather than the value at the call site so you cannot reference the program id until after it has been assigned.